### PR TITLE
Change episodes sort key

### DIFF
--- a/deploy/lib/anime.py
+++ b/deploy/lib/anime.py
@@ -66,7 +66,7 @@ class Anime(core.Stack):
             self,
             "anime_episodes",
             partition_key=Attribute(name="anime_id", type=AttributeType.STRING),
-            sort_key=Attribute(name="id", type=AttributeType.NUMBER),
+            sort_key=Attribute(name="episode_number", type=AttributeType.NUMBER),
             billing_mode=BillingMode.PAY_PER_REQUEST,
         )
 

--- a/src/layers/api/python/anidb.py
+++ b/src/layers/api/python/anidb.py
@@ -89,7 +89,7 @@ class AniDbApi:
 
             ep = {
                 "id": int(episode.attrib.get("id")),
-                "episode_number": epno.text,
+                "episode_number": int(epno.text),
                 "length": self._get_property(episode, "length"),
                 "air_date": self._get_property(episode, "airdate"),
                 "title": title

--- a/src/layers/databases/python/episodes_db.py
+++ b/src/layers/databases/python/episodes_db.py
@@ -48,18 +48,19 @@ def put_episodes(anime_id, episodes):
 
 def get_episodes(anime_id, limit=100, start=1):
     start_page = 0
+    total_pages = 0
     res = []
 
     if start <= 0:
         raise InvalidStartOffset
 
     for p in _episodes_generator(anime_id, limit):
+        total_pages += 1
         start_page += 1
         if start_page == start:
             res = p
-            break
 
-    if start_page < start:
+    if start > start_page:
         raise InvalidStartOffset
 
     log.debug(f"get_episodes response: {res}")
@@ -69,25 +70,8 @@ def get_episodes(anime_id, limit=100, start=1):
 
     return {
         "items": res,
-        "total": _episodes_count(anime_id)
+        "total_pages": total_pages
     }
-
-
-def _episodes_count(anime_id):
-    paginator = _get_client().get_paginator('query')
-
-    page_iterator = paginator.paginate(
-        TableName=DATABASE_NAME,
-        KeyConditionExpression="anime_id = :anime_id",
-        ExpressionAttributeValues={":anime_id": {"S": str(anime_id)}},
-        Limit=100,
-        ScanIndexForward=False
-    )
-
-    count = 0
-    for p in page_iterator:
-        count += len(p["Items"])
-    return count
 
 
 def _episodes_generator(anime_id, limit):

--- a/test/apitest/test_anime.py
+++ b/test/apitest/test_anime.py
@@ -44,9 +44,9 @@ def test_get_anime_episodes():
     assert res.status_code == 200
     item = res.json()
     assert len(item["items"]) == 100
-    assert item["items"][0]["episode_number"] == "220"
-    assert item["items"][-1]["episode_number"] == "121"
-    assert item["total"] == 220
+    assert item["items"][0]["episode_number"] == 220
+    assert item["items"][-1]["episode_number"] == 121
+    assert item["total_pages"] == 3
     time.sleep(1)
 
 
@@ -57,9 +57,9 @@ def test_get_anime_episodes_with_changed_limit():
     assert res.status_code == 200
     item = res.json()
     assert len(item["items"]) == 10
-    assert item["items"][0]["episode_number"] == "220"
-    assert item["items"][-1]["episode_number"] == "211"
-    assert item["total"] == 220
+    assert item["items"][0]["episode_number"] == 220
+    assert item["items"][-1]["episode_number"] == 211
+    assert item["total_pages"] == 23
     time.sleep(1)
 
 
@@ -70,9 +70,9 @@ def test_get_anime_episodes_with_changed_start_and_limit():
     assert res.status_code == 200
     item = res.json()
     assert len(item["items"]) == 10
-    assert item["items"][0]["episode_number"] == "210"
-    assert item["items"][-1]["episode_number"] == "201"
-    assert item["total"] == 220
+    assert item["items"][0]["episode_number"] == 210
+    assert item["items"][-1]["episode_number"] == 201
+    assert item["total_pages"] == 23
     time.sleep(1)
 
 

--- a/test/unittest/test_anime_episodes.py
+++ b/test/unittest/test_anime_episodes.py
@@ -31,7 +31,7 @@ def test_handler(mocked_episodes_db):
 
     exp = {
         "statusCode": 200,
-        "body": json.dumps({"items": exp_eps, "total": 2})
+        "body": json.dumps({"items": exp_eps, "total_pages": 1})
     }
     assert res == exp
 
@@ -88,7 +88,7 @@ def test_handler_with_limit(mocked_episodes_db):
 
     exp = {
         "statusCode": 200,
-        "body": json.dumps({"items": [exp_eps[0]], "total": 2})
+        "body": json.dumps({"items": [exp_eps[0]], "total_pages": 2})
     }
     assert res == exp
 
@@ -124,7 +124,7 @@ def test_handler_with_start(mocked_episodes_db):
 
     exp = {
         "statusCode": 200,
-        "body": json.dumps({"items": [exp_eps[1]], "total": 2})
+        "body": json.dumps({"items": [exp_eps[1]], "total_pages": 2})
     }
     assert res == exp
 
@@ -161,7 +161,7 @@ def test_handler_with_limit_and_start(mocked_episodes_db):
 
     exp = {
         "statusCode": 200,
-        "body": json.dumps({"items": [exp_eps[1]], "total": 2})
+        "body": json.dumps({"items": [exp_eps[1]], "total_pages": 2})
     }
     assert res == exp
 

--- a/test/unittest/test_episodes_db.py
+++ b/test/unittest/test_episodes_db.py
@@ -25,7 +25,7 @@ def test_get_episodes_with_limit(mocked_episodes_db):
     ]
 
     ret = mocked_episodes_db.get_episodes("123", limit=1)
-    assert ret == {"items": [{"ep_name": "ep_1"}], "total": 3}
+    assert ret == {"items": [{"ep_name": "ep_1"}], "total_pages": 3}
 
 
 def test_get_episodes_with_offset(mocked_episodes_db):
@@ -38,7 +38,7 @@ def test_get_episodes_with_offset(mocked_episodes_db):
     ]
 
     ret = mocked_episodes_db.get_episodes("123", limit=1, start=2)
-    assert ret == {"items": [{"ep_name": "ep_2"}], "total": 3}
+    assert ret == {"items": [{"ep_name": "ep_2"}], "total_pages": 3}
 
 
 def test_get_episodes_with_to_large_offset(mocked_episodes_db):


### PR DESCRIPTION
Use `episode_number` instead of episode id as sort key in episodes db. A lower episode number could still have a higher episode_number.

Extra:
* Refactor episodes generator and count method
* Return `total_pages` instead of `total` items