### PR TITLE
Check all anidb titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: test
 test:
 	pip install -U -r test/unittest/requirements.txt
+	pip install -U -r src/layers/api/requirements.txt
+	pip install -U -r src/layers/databases/requirements.txt
+	pip install -U -r src/layers/utils/requirements.txt
 	PYTHONPATH=./src/layers/api/python:./src/layers/common/python:./src/layers/utils/python:./src/lambdas/:./src/layers/databases/python \
 		pytest test/unittest --cov-report html --cov=src -vv
 

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -70,17 +70,19 @@ def handle(event, context):
 
 
 def _get_anidb_id(all_titles):
+    max_ratio_title = (None, 0)
     for title in all_titles:
         for anidb_title in _titles():
             compare_ratio = SequenceMatcher(None, title, anidb_title['title']).ratio()
-            if compare_ratio > 0.9:
-                log.info(f"Found anidb match >90%. Mal title: {title}. Anidb title: {anidb_title['title']}")
-                return anidb_title["id"]
+            if compare_ratio > 0.9 and compare_ratio > max_ratio_title[1]:
+                log.info(f"Found better anidb match >90%. Mal title: {title}. Anidb title: {anidb_title['title']}")
+                max_ratio_title = (anidb_title['title', compare_ratio])
             elif compare_ratio > 0.6:
                 log.info(f"Found 60%-90% match for mal title: {title}. Anidb title: {anidb_title['title']}")
 
-    log.warning(f"Could not find anidb_id for titles: {all_titles}")
-    return None
+    if max_ratio_title is None:
+        log.warning(f"Could not find anidb_id for titles: {all_titles}")
+    return max_ratio_title[0]
 
 
 def _titles():

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -75,7 +75,7 @@ def _get_anidb_id(all_titles):
         for anidb_title in _titles():
             compare_ratio = SequenceMatcher(None, title, anidb_title['title']).ratio()
             if compare_ratio > 0.9 and compare_ratio > max_ratio_title[1]:
-                log.info(f"Found better anidb match >90%. Mal title: {title}. Anidb title: {anidb_title['title']}")
+                log.info(f"Found better anidb match: {compare_ratio*100}%. Mal title: {title}. Anidb title: {anidb_title['title']}")
                 max_ratio_title = (anidb_title['title'], compare_ratio)
             elif compare_ratio > 0.6:
                 log.info(f"Found 60%-90% match for mal title: {title}. Anidb title: {anidb_title['title']}")

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -76,7 +76,7 @@ def _get_anidb_id(all_titles):
             compare_ratio = SequenceMatcher(None, title, anidb_title['title']).ratio()
             if compare_ratio > 0.9 and compare_ratio > max_ratio_title[1]:
                 log.info(f"Found better anidb match >90%. Mal title: {title}. Anidb title: {anidb_title['title']}")
-                max_ratio_title = (anidb_title['title', compare_ratio])
+                max_ratio_title = (anidb_title['title'], compare_ratio)
             elif compare_ratio > 0.6:
                 log.info(f"Found 60%-90% match for mal title: {title}. Anidb title: {anidb_title['title']}")
 


### PR DESCRIPTION
Look through all anidb titles in order to find the best possible match instead of just taking the first found with >90% compare ratio. This gets buggy if there are e.g. sequel animes with almost the same title.