### PR TITLE
Fix new post anime bugs

### DIFF
--- a/deploy/lib/anime.py
+++ b/deploy/lib/anime.py
@@ -265,8 +265,8 @@ class Anime(core.Stack):
                         resources=[self.anidb_titles_bucket.arn_for_objects("*")]
                     )
                 ],
-                "timeout": 15,
-                "memory": 1024
+                "timeout": 60,
+                "memory": 2048
             },
         }
 

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -75,7 +75,7 @@ def _get_anidb_id(all_titles):
         for anidb_title in _titles():
             compare_ratio = SequenceMatcher(None, title, anidb_title['title']).ratio()
             if compare_ratio == 1:
-                log.info(f"Found 100% equal anidb match. Mal title: {title}. Anidb title: {anidb_title['title']"})
+                log.info(f"Found 100% equal anidb match. Mal title: {title}. Anidb title: {anidb_title['title']}")
                 return anidb_title['id']
             if compare_ratio > 0.9 and compare_ratio > max_ratio_id[1]:
                 log.info(f"Found better anidb match: {compare_ratio*100}%. Mal title: {title}. Anidb title: {anidb_title['title']}")

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -83,7 +83,7 @@ def _get_anidb_id(all_titles):
             elif compare_ratio > 0.6:
                 log.info(f"Found 60%-90% match for mal title: {title}. Anidb title: {anidb_title['title']}")
 
-    if max_ratio_id is None:
+    if max_ratio_id[0] is None:
         log.warning(f"Could not find anidb_id for titles: {all_titles}")
     return max_ratio_id[0]
 

--- a/src/lambdas/sqs_handlers/post_anime/__init__.py
+++ b/src/lambdas/sqs_handlers/post_anime/__init__.py
@@ -70,19 +70,22 @@ def handle(event, context):
 
 
 def _get_anidb_id(all_titles):
-    max_ratio_title = (None, 0)
+    max_ratio_id = (None, 0)
     for title in all_titles:
         for anidb_title in _titles():
             compare_ratio = SequenceMatcher(None, title, anidb_title['title']).ratio()
-            if compare_ratio > 0.9 and compare_ratio > max_ratio_title[1]:
+            if compare_ratio == 1:
+                log.info(f"Found 100% equal anidb match. Mal title: {title}. Anidb title: {anidb_title['title']"})
+                return anidb_title['id']
+            if compare_ratio > 0.9 and compare_ratio > max_ratio_id[1]:
                 log.info(f"Found better anidb match: {compare_ratio*100}%. Mal title: {title}. Anidb title: {anidb_title['title']}")
-                max_ratio_title = (anidb_title['title'], compare_ratio)
+                max_ratio_id = (anidb_title['id'], compare_ratio)
             elif compare_ratio > 0.6:
                 log.info(f"Found 60%-90% match for mal title: {title}. Anidb title: {anidb_title['title']}")
 
-    if max_ratio_title is None:
+    if max_ratio_id is None:
         log.warning(f"Could not find anidb_id for titles: {all_titles}")
-    return max_ratio_title[0]
+    return max_ratio_id[0]
 
 
 def _titles():

--- a/test/unittest/test_sqs_post_anime.py
+++ b/test/unittest/test_sqs_post_anime.py
@@ -59,7 +59,7 @@ def test_handle(mocked_get, mocked_params_db, mocked_anime_db, mocked_anidb, moc
     # MAL request mock
     mocked_get.return_value.status_code = 200
     mocked_get.return_value.json = lambda *a, **k: TEST_MAL_RESPONSE.copy()
-
+    mocked_anidb.s3_bucket.download_file = download_file_mock
     # ANIDB request mock
     with open(ANIME_XML) as fs:
         mocked_get.return_value.text = fs.read()

--- a/test/unittest/test_sqs_post_anime.py
+++ b/test/unittest/test_sqs_post_anime.py
@@ -4,7 +4,7 @@ import shutil
 import time
 from unittest import mock
 
-from sqs_handlers.post_anime import handle
+from sqs_handlers.post_anime import handle, _get_anidb_id
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 ANIME_XML = os.path.join(CURRENT_DIR, "files", "anime.xml")
@@ -59,7 +59,7 @@ def test_handle(mocked_get, mocked_params_db, mocked_anime_db, mocked_anidb, moc
     # MAL request mock
     mocked_get.return_value.status_code = 200
     mocked_get.return_value.json = lambda *a, **k: TEST_MAL_RESPONSE.copy()
-    mocked_anidb.s3_bucket.download_file = download_file_mock
+
     # ANIDB request mock
     with open(ANIME_XML) as fs:
         mocked_get.return_value.text = fs.read()
@@ -168,3 +168,35 @@ def test_handle_no_anidb_match(mocked_get, mocked_params_db, mocked_anime_db, mo
 
     if os.path.isfile("titles.json"):
         os.remove("titles.json")
+
+
+def test_get_anidb_id(mocked_anidb):
+    mocked_anidb.s3_bucket.download_file = download_file_mock
+
+    anidb_id = _get_anidb_id(["Seikai no Monshou"])
+
+    assert anidb_id == 1
+
+
+def test_get_anidb_id_close_match(mocked_anidb):
+    mocked_anidb.s3_bucket.download_file = download_file_mock
+
+    anidb_id = _get_anidb_id(["Seikai no Monsh"])
+
+    assert anidb_id == 1
+
+
+def test_get_anidb_id_no_match(mocked_anidb):
+    mocked_anidb.s3_bucket.download_file = download_file_mock
+
+    anidb_id = _get_anidb_id(["abc"])
+
+    assert anidb_id is None
+
+
+def test_get_anidb_id_multiple_matches(mocked_anidb):
+    mocked_anidb.s3_bucket.download_file = download_file_mock
+
+    anidb_id = _get_anidb_id(["Seikai no Monsh", "Seikai no Monshou"])
+
+    assert anidb_id == 1


### PR DESCRIPTION
* Stop looking for anidb matches if a 100% match is found
* Return anidb ID if title matches, not the title itself
* Add more unittests for titles scanning function
* Increase sqs lambda timeout and memory