### PR TITLE
Mal proxy

### DIFF
--- a/deploy/lib/anime.py
+++ b/deploy/lib/anime.py
@@ -452,6 +452,25 @@ class Anime(core.Stack):
                 source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{http_api.http_api_id}/*"
             )
 
+        mal_proxy_integration = HttpIntegration(
+            self,
+            "mal_proxy_integration",
+            http_api=http_api,
+            integration_type=HttpIntegrationType.HTTP_PROXY,
+            integration_uri="https://api.myanimelist.net/v2/{proxy}",
+            method=HttpMethod.ANY,
+        )
+        CfnRoute(
+            self,
+            "mal_proxy_route",
+            api_id=http_api.http_api_id,
+            route_key="ANY /mal_proxy/{proxy+}",
+            authorization_type="JWT",
+            authorizer_id=authorizer.ref,
+            target="integrations/" + mal_proxy_integration.integration_id
+        )
+
+
         stage = CfnStage(
             self,
             "live",

--- a/deploy/lib/anime.py
+++ b/deploy/lib/anime.py
@@ -376,7 +376,7 @@ class Anime(core.Stack):
             cors_preflight=CorsPreflightOptions(
                 allow_methods=[HttpMethod.GET, HttpMethod.POST],
                 allow_origins=["https://moshan.tv", "https://beta.moshan.tv"],
-                allow_headers=["authorization", "content-type"]
+                allow_headers=["authorization", "content-type", "x-mal-client-id"]
             )
         )
 
@@ -469,7 +469,6 @@ class Anime(core.Stack):
             authorizer_id=authorizer.ref,
             target="integrations/" + mal_proxy_integration.integration_id
         )
-
 
         stage = CfnStage(
             self,


### PR DESCRIPTION
Add new `ANY /mal_proxy/{proxy+}` route working as a proxy towards mal api. This way frontend can just hardcode the 'public' mal client ID and use it (together with moshan JWT) to bypass CORS until the new (beta) API exposes public routes in a more straightforward manner.