### PR TITLE
Change proxy from any to GET

### DIFF
--- a/deploy/lib/anime.py
+++ b/deploy/lib/anime.py
@@ -465,7 +465,7 @@ class Anime(core.Stack):
             self,
             "mal_proxy_route",
             api_id=http_api.http_api_id,
-            route_key="ANY /v1/mal_proxy/{proxy+}",
+            route_key="GET /v1/mal_proxy/{proxy+}",
             authorization_type="JWT",
             authorizer_id=authorizer.ref,
             target="integrations/" + mal_proxy_integration.integration_id,


### PR DESCRIPTION
Change `ANY /v1/mal_proxy/{proxy+}` into `GET /v1/mal_proxy/{proxy+}` in order to handle preflight requests by AWS gateway instead of being proxied to mal api. 