### PR TITLE
Fix consistent get by api

### DIFF
--- a/src/lambdas/api/anime/__init__.py
+++ b/src/lambdas/api/anime/__init__.py
@@ -95,11 +95,32 @@ def _get_anime_by_api_id(query_params):
             "body": json.dumps({"error": "Please specify query parameters"})
         }
 
-    if "mal_id" in query_params:
+    if "api_id" not in query_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_id query parameter"})
+        }
+
+    if "api_name" not in query_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_name query parameter"})
+        }
+
+    api_id = int(query_params["api_id"])
+    api_name = query_params["api_name"]
+
+    if api_name in ["mal"]:
         try:
-            res = anime_db.get_anime_by_api_id("mal", int(query_params["mal_id"]))
-            return {"statusCode": 200, "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)}
+            res = anime_db.get_anime_by_api_id(api_name, api_id)
+            return {
+                "statusCode": 200,
+                "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)
+            }
         except anime_db.NotFoundError:
             return {"statusCode": 404}
     else:
-        return {"statusCode": 400, "body": json.dumps({"error": "Unsupported query param"})}
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Unsupported api_name"})
+        }

--- a/src/lambdas/api/anime_episodes/__init__.py
+++ b/src/lambdas/api/anime_episodes/__init__.py
@@ -69,24 +69,25 @@ def _post(body):
 
 
 def _get(anime_id, query_params):
-    if "api_id" in query_params:
-        return _get_episode_by_api_id(query_params)
+    if "api_id" in query_params and "api_name" in query_params:
+        api_id = int(query_params["api_id"])
+        api_name = query_params["api_name"]
+        return _get_episode_by_api_id(api_id, api_name)
     else:
         return _get_episodes(anime_id, query_params)
 
 
-def _get_episode_by_api_id(query_params):
-    if query_params["api_name"] == "anidb":
+def _get_episode_by_api_id(api_id, api_name):
+    if api_name in ["anidb"]:
         try:
-            res = episodes_db.get_episode_by_api_id("anidb",
-                                                    int(query_params["api_id"]))
+            res = episodes_db.get_episode_by_api_id(api_name, api_id)
             return {"statusCode": 200,
                     "body": json.dumps(res, cls=decimal_encoder.DecimalEncoder)}
         except (episodes_db.NotFoundError, episodes_db.InvalidAmountOfEpisodes):
             return {"statusCode": 404}
     else:
         return {"statusCode": 400,
-                "body": json.dumps({"error": "Unsupported query param"})}
+                "body": json.dumps({"error": "Unsupported api_name"})}
 
 
 def _get_episodes(anime_id, query_params):

--- a/test/unittest/test_anime.py
+++ b/test/unittest/test_anime.py
@@ -161,7 +161,7 @@ class TestGet:
         }
         assert res == exp
 
-    def test_get_invalid_query_params(self):
+    def test_invalid_query_params(self):
         event = copy.deepcopy(self.event)
         event["queryStringParameters"] = {
             "abc": "123"
@@ -172,5 +172,29 @@ class TestGet:
         exp = {
             "statusCode": 400,
             "body": json.dumps({"error": "Missing api_id query parameter"})
+        }
+        assert res == exp
+
+    def test_missing_api_name(self):
+        event = copy.deepcopy(self.event)
+        del event["queryStringParameters"]["api_name"]
+
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Missing api_name query parameter"})
+        }
+        assert res == exp
+
+    def test_invalid_api_name(self):
+        event = copy.deepcopy(self.event)
+        event["queryStringParameters"]["api_name"] = "INVALID"
+
+        res = handle(event, None)
+
+        exp = {
+            "statusCode": 400,
+            "body": json.dumps({"error": "Unsupported api_name"})
         }
         assert res == exp

--- a/test/unittest/test_anime.py
+++ b/test/unittest/test_anime.py
@@ -136,7 +136,8 @@ def test_get_mal_id_in_db(mocked_anime_db):
             }
         },
         "queryStringParameters": {
-            "mal_id": "123"
+            "api_id": "123",
+            "api_name": "mal"
         }
     }
 
@@ -158,7 +159,8 @@ def test_get_mal_id_not_found(mocked_anime_db):
             }
         },
         "queryStringParameters": {
-            "mal_id": "123"
+            "api_id": "123",
+            "api_name": "mal",
         }
     }
 
@@ -206,6 +208,6 @@ def test_get_invalid_query_params():
 
     exp = {
         "statusCode": 400,
-        "body": json.dumps({"error": "Unsupported query param"})
+        "body": json.dumps({"error": "Missing api_id query parameter"})
     }
     assert res == exp

--- a/test/unittest/test_anime_episodes.py
+++ b/test/unittest/test_anime_episodes.py
@@ -420,6 +420,6 @@ class TestGetEpisodeByApiId:
 
         res = handle(self.event, None)
 
-        exp = {"body": '{"error": "Unsupported query param"}',
+        exp = {"body": '{"error": "Unsupported api_name"}',
                "statusCode": 400}
         assert res == exp


### PR DESCRIPTION
* Use `api_name` and `api_id` query params in `GET /anime` route